### PR TITLE
[Chore/#74] 유입 채널 수정 request, 보헙 정보 API의 uri 수정

### DIFF
--- a/src/main/java/FITPET/dev/controller/InsuranceController.java
+++ b/src/main/java/FITPET/dev/controller/InsuranceController.java
@@ -61,7 +61,7 @@ public class InsuranceController {
         return ApiResponse.SuccessResponse(SuccessStatus.UPDATE_INSURANCE_SUCCESS, insuranceService.updateInsurancePremium(insuranceId, premium));
     }
 
-    @GetMapping("/admin/insurance/premium/{insuranceId}")
+    @GetMapping("/admin/insurance/history/{insuranceId}")
     @Operation(summary = "보험료 수정 내역 조회 API", description = "특정 보험id의 보험료 수정 내역을 조회")
     public ApiResponse getPremiumHistory(
             @PathVariable(name = "insuranceId") Long insuranceId
@@ -70,7 +70,7 @@ public class InsuranceController {
         return ApiResponse.SuccessResponse(SuccessStatus.GET_INSURANCE_PREMIUM_HISTORY, response);
     }
 
-    @PostMapping("/admin/insurance/add")
+    @PostMapping("/admin/insurance")
     @Operation(summary = "보험 정보 추가 API", description = "새로운 보험 정보를 추가")
     public ApiResponse addInsurance(
             @RequestBody InsuranceRequest request
@@ -79,7 +79,7 @@ public class InsuranceController {
     }
 
     // 보험 정보 삭제 API
-    @DeleteMapping("/admin/insurance/delete/{insuranceId}")
+    @DeleteMapping("/admin/insurance/{insuranceId}")
     @Operation(summary = "보험 정보 삭제 API", description = "해당 보험 id의 보험 정보를 삭제")
     public ApiResponse deleteInsurance(@PathVariable Long insuranceId) {
         insuranceService.deleteInsurance(insuranceId);

--- a/src/main/java/FITPET/dev/dto/request/ReferSiteRequest.java
+++ b/src/main/java/FITPET/dev/dto/request/ReferSiteRequest.java
@@ -12,11 +12,8 @@ public class ReferSiteRequest {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class ReferSiteDto {
-        @NotBlank(message = "채널을 입력해주세요")
         private String channel;
-        @NotBlank(message = "채널 url을 입력해주세요")
         private String url;
-        @NotBlank(message = "채널의 한글명을 입력해주세요")
         private String channelKor;
     }
 


### PR DESCRIPTION
### #️⃣ 관련 이슈
closed #74 

### 💡 작업내용
1. 유입 채널 수정 request @NotBlank 어노테이션 삭제

2.  보험 정보 API의 URI 수정
- 보험료 히스토리 조회 API : premium -> history
- 보험 정보 row 추가 API : add 삭제
- 보험 정보 row 삭제 AP I : delete 삭제
### 📸 스크린샷(선택)

### 📝 기타
(참고사항, 리뷰어에게 전하고 싶은 말 등을 넣어주세요)
